### PR TITLE
Fix/re-enable quoted_insert: use self.evt.data

### DIFF
--- a/pyrepl/commands.py
+++ b/pyrepl/commands.py
@@ -369,8 +369,12 @@ class invalid_command(Command):
 
 class qIHelp(Command):
     def do(self):
+        from .reader import disp_str
+
         r = self.reader
-        r.insert((bytes(self.event) + r.console.getpending().data) * r.get_arg())
+        pending = r.console.getpending().data
+        disp = disp_str((self.event + pending).encode())[0]
+        r.insert(disp * r.get_arg())
         r.pop_input_trans()
 
 from pyrepl import input
@@ -379,7 +383,7 @@ class QITrans(object):
     def push(self, evt):
         self.evt = evt
     def get(self):
-        return ('qIHelp', self.evt.raw)
+        return ('qIHelp', self.evt.data)
 
 class quoted_insert(Command):
     kills_digit_arg = 0

--- a/pyrepl/commands.py
+++ b/pyrepl/commands.py
@@ -373,7 +373,7 @@ class qIHelp(Command):
 
         r = self.reader
         pending = r.console.getpending().data
-        disp = disp_str((self.event + pending).encode())[0]
+        disp = disp_str((self.event + pending))[0]
         r.insert(disp * r.get_arg())
         r.pop_input_trans()
 

--- a/testing/infrastructure.py
+++ b/testing/infrastructure.py
@@ -55,6 +55,10 @@ class TestConsole(Console):
             print("event", ev)
         return Event(*ev)
 
+    def getpending(self):
+        """Nothing pending, but do not return None here."""
+        return Event('key', '', b'')
+
 
 class TestReader(Reader):
     __test__ = False

--- a/testing/test_wishes.py
+++ b/testing/test_wishes.py
@@ -27,5 +27,5 @@ def test_quoted_insert_repeat():
     read_spec([
         (('digit-arg', '3'),      ['']),
         (('quoted-insert', None), ['']),
-        (('self-insert', '\033'), ['^[^[^[']),
+        (('key', '\033'),         ['^[^[^[']),
         (('accept', None),        None)])


### PR DESCRIPTION
Reverts https://github.com/pypy/pyrepl/commit/a59f338cc7b6c.

Fixes:

      File "/usr/lib/python3.7/cmd.py", line 126, in cmdloop
        line = input(self.prompt)
      File "…/src/pyrepl/pyrepl/readline.py", line 229, in raw_input
        ret = reader.readline(startup_hook=self.startup_hook)
      File "…/src/pyrepl/pyrepl/reader.py", line 605, in readline
        self.handle1()
      File "…/src/pyrepl/pyrepl/reader.py", line 588, in handle1
        self.do_cmd(cmd)
      File "…/src/pyrepl/pyrepl/reader.py", line 535, in do_cmd
        cmd.do()
      File "…/src/pyrepl/pyrepl/commands.py", line 373, in do
        r.insert((self.event + r.console.getpending().data) * r.get_arg())
    TypeError: can't concat str to bytearray

(happens with `Ctrl-q` + something in pdbpp prompt)

Taken out of https://github.com/pypy/pyrepl/pull/2.