### PR TITLE
setupterm: improve error msg, encode non-bytes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: true
+    patch: true
+    changes: true
+comment: false

--- a/pyrepl/_minimal_curses.py
+++ b/pyrepl/_minimal_curses.py
@@ -52,10 +52,14 @@ except ImportError:
 
 @builtinify
 def setupterm(termstr, fd):
+    if termstr is not None:
+        if not isinstance(termstr, bytes):
+            termstr = termstr.encode()
     err = ctypes.c_int(0)
     result = clib.setupterm(termstr, fd, ctypes.byref(err))
     if result == ERR:
-        raise error("setupterm() failed (err=%d)" % err.value)
+        raise error("setupterm(%r, %d) failed (err=%d)" % (
+            termstr, fd, err.value))
 
 
 @builtinify

--- a/testing/test_curses.py
+++ b/testing/test_curses.py
@@ -1,0 +1,23 @@
+import pytest
+from pyrepl.curses import setupterm
+import pyrepl
+
+
+def test_setupterm(monkeypatch):
+    assert setupterm(None, 0) is None
+
+    with pytest.raises(
+        pyrepl._minimal_curses.error,
+        match=r"setupterm\(b?'term_does_not_exist', 0\) failed \(err=0\)",
+    ):
+        setupterm("term_does_not_exist", 0)
+
+    monkeypatch.setenv('TERM', 'xterm')
+    assert setupterm(None, 0) is None
+
+    monkeypatch.delenv('TERM')
+    with pytest.raises(
+        pyrepl._minimal_curses.error,
+        match=r"setupterm\(None, 0\) failed \(err=-1\)",
+    ):
+        setupterm(None, 0)


### PR DESCRIPTION
`termstr` is always passed as `None`, which results in it being looked
up from the `$TERM` environment variable.  This might be absent though,
e.g. within tox when not used in `passenv`.