### PR TITLE
try importing built-in module first

### DIFF
--- a/pyrepl/curses.py
+++ b/pyrepl/curses.py
@@ -1,4 +1,4 @@
-
+from __future__ import absolute_import
 #   Copyright 2000-2010 Michael Hudson-Doyle <micahel@gmail.com>
 #                       Armin Rigo
 #
@@ -19,5 +19,8 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-
-from ._minimal_curses import setupterm, tigetstr, tparm, error
+# First try the built-in module
+try:
+    from _minimal_curses import setupterm, tigetstr, tparm, error
+except ImportError:
+    from ._minimal_curses import setupterm, tigetstr, tparm, error

--- a/testing/test_curses.py
+++ b/testing/test_curses.py
@@ -1,5 +1,8 @@
 import pytest
-from pyrepl.curses import setupterm
+try:
+    from pyrepl.curses import setupterm, error as curses_error
+except ImportError:
+    pytest.skip('cannot import curses', allow_module_level=True)
 import pyrepl
 
 
@@ -17,7 +20,7 @@ def test_setupterm(monkeypatch):
 
     monkeypatch.delenv('TERM')
     with pytest.raises(
-        pyrepl._minimal_curses.error,
+        curses_error,
         match=r"setupterm\(None, 0\) failed \(err=-1\)",
     ):
         setupterm(None, 0)


### PR DESCRIPTION
The python3 relative import `import ._minimal_curses` will import `pyrepl/_minimal_curses.py`, so give a chance to the built-in `_minimal_curses` first