### PR TITLE
Revert "setup.py: use versioning=dev"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ command line interfaces, featuring:
 setup(
     name="pyrepl",
     setup_requires="setupmeta",
-    versioning="dev",
+    versioning="devcommit",
     author="Michael Hudson-Doyle",
     author_email="micahel@gmail.com",
     maintainer="Daniel Hahler",


### PR DESCRIPTION
Reverts pypy/pyrepl#16

versioning=devcommit is more explicit / provides more info.