### PR TITLE
Fix suspending with process groups

### DIFF
--- a/pyrepl/commands.py
+++ b/pyrepl/commands.py
@@ -192,7 +192,7 @@ class suspend(Command):
         r = self.reader
         p = r.pos
         r.console.finish()
-        os.kill(os.getpid(), signal.SIGSTOP)
+        os.kill(0, signal.SIGSTOP)
         ## this should probably be done
         ## in a handler for SIGCONT?
         r.console.prepare()


### PR DESCRIPTION
Since using raw mode via `raw.lflag &= ~(… | termios.ISIG)` pyrepl needs
to handle SIGSTOP itself, but before this patch would only signal its
own process.
Using `0` for the pid signals the process group instead.

Manual test:

When running the following from a shell `Ctrl-z` will not give you the
shell's prompt, but the process is stuck, and needs to be signaled to
continue using `kill -CONT $pid`:

> python -c 'import os; os.system("python pyrepl/reader.py")'

I have noticed this when using pdbpp with pytest, which was wrapped in a
shell script, not using `exec python …`.