### PR TITLE
Use pid=0 (process group) with emitting SIGINT

### DIFF
--- a/pyrepl/commands.py
+++ b/pyrepl/commands.py
@@ -184,7 +184,7 @@ class interrupt(FinishCommand):
     def do(self):
         import signal
         self.reader.console.finish()
-        os.kill(os.getpid(), signal.SIGINT)
+        os.kill(0, signal.SIGINT)
 
 class suspend(Command):
     def do(self):


### PR DESCRIPTION
I have not seen this to be necessary, but it goes in line with handling
SIGSTOP then (https://github.com/pypy/pyrepl/pull/49).