### PR TITLE
fix list index out of range in forward search

### DIFF
--- a/pyrepl/historical_reader.py
+++ b/pyrepl/historical_reader.py
@@ -275,7 +275,7 @@ class HistoricalReader(R):
                 self.select_item(i)
                 self.pos = p
                 return
-            elif ((forwards and i == len(self.history) - 1)
+            elif ((forwards and i >= len(self.history) - 1)
                   or (not forwards and i == 0)):
                 self.error("not found")
                 return


### PR DESCRIPTION
The "IndexError: list index out of range" error can be easily reproduced in `pythoni`
1. press `ctrl + s` to enter forward search
2. press any key, and the error will appear

```
$ python3 pythoni
Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(f-search `') Traceback (most recent call last):
  File "/home/yonl/pyrepl/pythoni", line 36, in <module>
    main(use_pygame_console=('pg' in sys.argv))
  File "/home/yonl/pyrepl/pyrepl/python_reader.py", line 403, in main
    getattr(rc, interactmethod)()
  File "/home/yonl/pyrepl/pyrepl/python_reader.py", line 207, in interact
    l = unicode(self.reader.readline(), 'utf-8')
  File "/home/yonl/pyrepl/pyrepl/reader.py", line 605, in readline
    self.handle1()
  File "/home/yonl/pyrepl/pyrepl/reader.py", line 588, in handle1
    self.do_cmd(cmd)
  File "/home/yonl/pyrepl/pyrepl/reader.py", line 535, in do_cmd
    cmd.do()
  File "/home/yonl/pyrepl/pyrepl/historical_reader.py", line 143, in do
    r.isearch_next()
  File "/home/yonl/pyrepl/pyrepl/historical_reader.py", line 285, in isearch_next
    s = self.get_item(i)
  File "/home/yonl/pyrepl/pyrepl/historical_reader.py", line 235, in get_item
    return self.transient_history.get(i, self.history[i])
IndexError: list index out of range
```